### PR TITLE
Adding Authentication to API Spec

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -216,13 +216,6 @@ paths:
             application/json:
               schema:
                 # TODO
-  /api/member/{memberID}/resetPassword:
-    parameters:
-      - name: memberID
-        in: path
-        required: true
-        schema:
-          type: integer
   /api/member/list:
     get:
       tags:


### PR DESCRIPTION
After further research, we have determined that manually defining the Authorization header would just be ignored. In response to this, descriptions for endpoints requiring a JWT ID Token have been noted, and a BearerAuth security scheme has been added.
